### PR TITLE
feat: Add ability to set maxBuffer parameter for spawnSync while executing checkov

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ new CheckovValidator({
     skipCheck: ['CKV_AWS_18', 'CKV_AWS_21'],
 });
 ```
+
+### Troubleshooting
+
+If you are getting `Error: spawnSync checkov ENOBUFS` error, please try to set `CHECKOV_MAX_BUFFER_SIZE_MB` environment variable to numeric value above 1. It's setting `maxBuffer` parameter for `spawnSync` [function](https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options) under the hood.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ export function exec(commandLine: string[], options: { cwd?: string; json?: bool
       ...options.env,
     },
     cwd: options.cwd,
+    maxBuffer: 1024 * 1024 * (parseInt(process.env['CHECKOV_MAX_BUFFER_SIZE_MB']) || 1),
   });
 
   if (proc.error) { throw proc.error; }


### PR DESCRIPTION
This was result of https://github.com/bridgecrewio/cdk-validator-checkov/issues/8 . When `spawnSync` was called, `Error: spawnSync checkov ENOBUFS` error could be returned if `checkov` command returned a lot of content. Turns out that this error could be avoided if `maxBuffer` value for `spawnSync` was increased (1 Mb by default). This PR allows to change this value by setting `CHECKOV_MAX_BUFFER_SIZE_MB` environment variable.